### PR TITLE
Linux install.sh 1.0.11

### DIFF
--- a/install/linux/install.sh
+++ b/install/linux/install.sh
@@ -30,7 +30,7 @@ readonly YELLOW='\033[1;33m'
 readonly BLUE='\033[0;34m'
 readonly NC='\033[0m'
 
-readonly CLI_VERSION="1.0.10"
+readonly CLI_VERSION="1.0.11"
 
 # Configuration (see ENVIRONMENT VARIABLE OVERRIDES section above)
 NODE_VERSION="${FDMM_NODE_VERSION:-24.12.0}"


### PR DESCRIPTION
Allows specifying NPM package version to install

Enables users to install specific versions of the NPM package by providing the `FDMM_NPM_PACKAGE_VERSION` environment variable.

This ensures compatibility and allows for testing with different versions. It also fixes an issue where the package installation would fail when a version was explicitly provided.