### PR TITLE
Ensures Node.js and Yarn before upgrade

### DIFF
--- a/install/linux/install.sh
+++ b/install/linux/install.sh
@@ -486,6 +486,12 @@ handle_command() {
 
             print_info "Upgrading FDM Monster to $VERSION_DISPLAY..."
             $0 stop
+
+            # Ensure Node.js and Yarn are available
+            print_info "Checking FDM Monster requirements..."
+            ensure_nodejs
+            setup_yarn
+
             cd "$INSTALL_DIR"
 
             # Install package with or without version


### PR DESCRIPTION
Ensures that Node.js and Yarn are available before upgrading FDM Monster. This prevents upgrade failures due to missing dependencies.