### PR TITLE
Splits install process into user and root steps

### DIFF
--- a/install/linux/macvlan-setup.sh
+++ b/install/linux/macvlan-setup.sh
@@ -85,7 +85,6 @@ service:
     deploy:
       restart_policy:
         delay: 5s
-        #max_attempts: 3
         window: 120s
     networks:
       ${name}: # rename to mach your config option below


### PR DESCRIPTION
Implements separate `install-user` and `install-root` commands to allow installation in environments where root access is not immediately available or desirable.

- Modifies the install script to support user-level installation, deferring systemd service setup to a separate root-level installation step.
- Adds a new command-line option `install-user` that performs user-specific installation steps without requiring `sudo`.
- Introduces a new command-line option `install-root` to execute root-level tasks like systemd service setup.
- Skips sudo checks for the user-level installation, adapting the installation process for `chroot` environments.
- Bumps the CLI version to 1.0.15.